### PR TITLE
Update Clap to 4.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,60 @@
+name: Rust CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        rust: [stable, nightly]
+        os: [macos-latest, windows-latest, ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Build
+      run: |
+        rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+        cargo build
+
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    needs: [build]
+
+    strategy:
+      matrix:
+        rust: [stable, nightly]
+        os: [macos-latest, windows-latest, ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Test
+      run: |
+        rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+        cargo test
+
+  rustfmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Rustfmt Check
+      run: |
+        rustup update stable && rustup default stable && rustup component add rustfmt
+        cargo fmt -- --check
+
+  clippy-check:
+    name: Clippy Check
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        components: clippy
+        override: true

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ Cargo.lock
 *.ko
 *.ksm
 *.ks
+
+*.vim
+*.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "klinker"
 version = "2.0.10"
 authors = ["Luke Newcomb <newcomb.luke@protonmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0"
 description = "The Kerbal Compiler Collection linker for kOS"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "klinker"
-version = "2.0.10"
+version = "3.0.0"
 authors = ["Luke Newcomb <newcomb.luke@protonmail.com>"]
 edition = "2021"
 license = "GPL-3.0"
@@ -9,7 +9,7 @@ readme = "README.md"
 homepage = "https://github.com/newcomb-luke/kOS-KLinker"
 
 [dependencies]
-clap = "~2.34.0"
+clap = { version = "4.0.18", features = ["derive"] }
 flate2 = "1.0"
 kerbalobjects = "3.1.13"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "klinker"
-version = "3.0.0"
+version = "2.0.11"
 authors = ["Luke Newcomb <newcomb.luke@protonmail.com>"]
 edition = "2021"
 license = "GPL-3.0"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 The Kerbal Linker, or KLinker is a completely custom built linker designed to support development of a compiler toolchain for Kerbal Operating System. KLinker links KerbalObject files into KerboScript Machine Code files which can be run inside of kOS.
 
+To be able to inspect the files that this program consumes and outputs, the tool [kDump](https://github.com/newcomb-luke/KDump) was created.
+
 This linker will successfully create both executables and shared libraries if supplied compliant KerbalObject files that follow the KerbalObject file format [specification](https://github.com/newcomb-luke/kOS-KLinker/blob/main/docs/KO-file-format.md). These KerbalObject files can be created by any assembler or compiler built to emit them, such as the [Kerbal Assembler](https://github.com/newcomb-luke/kOS-KASM). 
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
 # Kerbal Linker (kld)
 
-[![Libraries.io dependency status for GitHub repo](https://img.shields.io/librariesio/github/newcomb-luke/kOS-KLinker)](https://deps.rs/repo/github/newcomb-luke/kOS-KLinker)
-![GitHub](https://img.shields.io/github/license/newcomb-luke/kOS-KLinker)
-
-![Crates.io](https://img.shields.io/crates/v/klinker?color=%235555cc)
-
-![Cra[<img src="https://img.shields.io/badge/github-newcomb--luke%2FkOS--KLinker-8da0cb?style=for-the-badge&logo=github&labelColor=555555" alt="github" height="24">](https://github.com/newcomb-luke/kOS-KLinker)
+[<img src="https://img.shields.io/badge/github-newcomb--luke%2FkOS--KLinker-8da0cb?style=for-the-badge&logo=github&labelColor=555555" alt="github" height="24">](https://github.com/newcomb-luke/kOS-KLinker)
 [<img src="https://img.shields.io/crates/v/klinker?color=fc8d62&logo=rust&style=for-the-badge" alt="github" height="24">](https://crates.io/crates/klinker)
 [<img alt="License" src="https://img.shields.io/github/license/newcomb-luke/kOS-KLinker?style=for-the-badge" height="24">]()
 

--- a/README.md
+++ b/README.md
@@ -4,49 +4,77 @@
 ![GitHub](https://img.shields.io/github/license/newcomb-luke/kOS-KLinker)
 
 ![Crates.io](https://img.shields.io/crates/v/klinker?color=%235555cc)
-![Crates.io](https://img.shields.io/crates/d/klinker)
+
+![Cra[<img src="https://img.shields.io/badge/github-newcomb--luke%2FkOS--KLinker-8da0cb?style=for-the-badge&logo=github&labelColor=555555" alt="github" height="24">](https://github.com/newcomb-luke/kOS-KLinker)
+[<img src="https://img.shields.io/crates/v/klinker?color=fc8d62&logo=rust&style=for-the-badge" alt="github" height="24">](https://crates.io/crates/klinker)
+[<img alt="License" src="https://img.shields.io/github/license/newcomb-luke/kOS-KLinker?style=for-the-badge" height="24">]()
+
+[<img alt="GitHub Workflow Status" src="https://img.shields.io/github/workflow/status/newcomb-luke/kOS-KLinker/Rust%20CI?style=for-the-badge" height="24">]()
+[<img alt="Libraries.io dependency status for GitHub repo" src="https://img.shields.io/librariesio/github/newcomb-luke/kOS-KLinker?style=for-the-badge" height="24">](https://deps.rs/repo/github/newcomb-luke/kOS-KLinker)
+[<img alt="Crates.io Downloads" src="https://img.shields.io/crates/d/klinker?style=for-the-badge" height="24">]()
 
 The Kerbal Linker, or KLinker is a completely custom built linker designed to support development of a compiler toolchain for Kerbal Operating System. KLinker links KerbalObject files into KerboScript Machine Code files which can be run inside of kOS.
 
 This linker will successfully create both executables and shared libraries if supplied compliant KerbalObject files that follow the KerbalObject file format [specification](https://github.com/newcomb-luke/kOS-KLinker/blob/main/docs/KO-file-format.md). These KerbalObject files can be created by any assembler or compiler built to emit them, such as the [Kerbal Assembler](https://github.com/newcomb-luke/kOS-KASM). 
 
+## Features
+
+* Symbol relocation
+* Local symbol support
+* Link-time file size optimization
+
 ## Installation
 
 The Kerbal Linker can either be installed via [cargo](https://github.com/rust-lang/cargo) through [crates.io](https://crates.io/), or as a standalone binary.
 
-To install using **cargo**:
+#### Windows
+
+- Download the .msi file from Releases on the right
+- Run the installer
+- **kld** should now be added to your PATH and available from any CMD or Powershell window
+
+#### Arch Linux
+
+- Download the PKGBUILD from Releases on the right
+
+- Copy it to a temporary folder
+
+- Run `makepkg -si` to install **klinker** and all of its dependencies.
+
+- **kld** should now be added to your PATH and available from any terminal
+
+#### Standalone Executables
+
+- Download and extract the .zip file from Releases on the right
+- Place the executable in the desired location
+- Run the executable through the terminal, Powershell on Windows or the default terminal on Mac OS or Linux.
+
+#### Cargo
 
 ```
 cargo install klinker
 ```
 
-`kld` should then be added to your shell's PATH, and can be run from any terminal
-
-To install using the standalone binaries:
-* Download and extract the .zip file from Releases on the right
-* Place the executable in the desired location
-* Run the executable through the terminal, Powershell on Windows or the default terminal on Mac OS or Linux.
-
-To install using the Windows installer:
-* Download the .msi file from Releases on the right
-* Run the installer
-* `kld` should now be added to your PATH and available from any CMD or Powershell window
+**kld** should then be added to your shell's PATH, and can be run from any terminal
 
 ## Usage
 
-The Kerbal Linker can be invoked after installation as `kld`
+The Kerbal Linker can be invoked after installation as **kld**
 
 Help can be accessed from the program itself by running:
+
 ```
 kld --help
 ```
 
 The basic format for kld arguments is:
+
 ```
 kld [FLAGS] [OPTIONS] <INPUT>... -o <OUTPUT PATH>
 ```
 
 When running `kld`, the linker cannot infer the output file name, so one must always be specified. This is accomplished by passing the **-o** flag to kld:
+
 ```
 kld -o myprogram.ksm
 ```
@@ -54,11 +82,13 @@ kld -o myprogram.ksm
 If the output path does not end in .ksm, kld will attempt to add it.
 
 kld is able to take more than one file as input at a time, and multiple input files are input as paths separated by spaces:
+
 ```
 kld librocket.ko mathlib.ko main.ko -o launch.ksm
 ```
 
 The **-s** flag can be specified to put the linker into shared library mode. This mode requires only the _init function to be present.
+
 ```
 kld libdock.ko librendezv.ko -o docking.ksm
 ```
@@ -66,17 +96,12 @@ kld libdock.ko librendezv.ko -o docking.ksm
 This file cannot be run directly, and instead should be loaded from another program.
 
 kld also allows the user to specify the entry point of the program, or the function that the program starts running from. By default this is the _start function. This can be changed by using the **-e** flag:
+
 ```
 kld -e __main__ main.ko -o program.ksm
 ```
 
 This will make the linker search for a function with the name "\_\_main\_\_" and then create the KSM file so that that code is what is run when the program starts up.
-
-## Features
-
-* Symbol relocation
-* Local symbol support
-* Link-time file size optimization
 
 ## Notes
 

--- a/src/driver/reader.rs
+++ b/src/driver/reader.rs
@@ -1,10 +1,10 @@
+use std::path::PathBuf;
 use std::{
     collections::{hash_map::DefaultHasher, HashMap},
     ffi::OsString,
     hash::Hasher,
     io::Read,
     num::NonZeroUsize,
-    path::Path,
 };
 
 use kerbalobjects::{
@@ -26,13 +26,12 @@ use super::errors::{FileErrorContext, FuncErrorContext, LinkError, LinkResult, P
 pub struct Reader {}
 
 impl Reader {
-    pub fn read_file(path: String) -> LinkResult<(String, KOFile)> {
-        let copied_path = String::clone(&path);
-        let path_obj = Path::new(&path);
+    pub fn read_file(path: impl Into<PathBuf>) -> LinkResult<(String, KOFile)> {
+        let path = path.into();
 
-        let file_name_os = path_obj
-            .file_name()
-            .ok_or(LinkError::InvalidPathError(copied_path))?;
+        let file_name_os = path.file_name().ok_or(LinkError::InvalidPathError(
+            path.to_str().unwrap().to_string(),
+        ))?;
         let file_name = file_name_os
             .to_owned()
             .into_string()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,51 +1,10 @@
-use clap::{App, Arg};
+use clap::Parser;
 use std::process;
 
 use klinker::{run, CLIConfig};
 
 fn main() {
-    let matches = App::new("Kerbal Linker")
-        .version(klinker::VERSION)
-        .author("Luke Newcomb")
-        .about("Links KerbalObject files into KSM files to be run by kOS.")
-        .arg(
-            Arg::with_name("INPUT")
-                .help("Sets the input file(s) to use")
-                .required(true)
-                .index(1)
-                .min_values(1)
-        )
-        .arg(
-            Arg::with_name("output_path")
-                .help("Sets the output file to use")
-                .short("o")
-                .long("output")
-                .takes_value(true)
-                .required(true)
-        )
-        .arg(
-            Arg::with_name("entry_point")
-                .help("The name of the function that the program should begin execution")
-                .short("e")
-                .long("entry-point")
-                .takes_value(true)
-                .default_value("_start")
-        )
-        .arg(
-            Arg::with_name("shared_object")
-                .help("Will link the object files into a shared object file instead of being linked into an executable file")
-                .short("s")
-                .long("shared")
-        )
-        .arg(
-            Arg::with_name("debug")
-                .help("Outputs some debugging information that probably is only useful for developers of this tool")
-                .short("d")
-                .long("debug")
-        )
-        .get_matches();
-
-    let config = CLIConfig::new(matches);
+    let config = CLIConfig::parse();
 
     if let Err(e) = run(&config) {
         eprintln!("{}", e);

--- a/tests/global-test.rs
+++ b/tests/global-test.rs
@@ -1,4 +1,5 @@
 use std::io::{Read, Write};
+use std::path::PathBuf;
 
 use kerbalobjects::{
     kofile::{
@@ -39,14 +40,14 @@ fn link_with_globals() {
     let lib_ko = KOFile::from_bytes(&mut buffer_iter, false).expect("Error reading KO file");
 
     let config = CLIConfig {
-        file_paths: Vec::new(),
-        output_path_value: String::from("./tests/global/globals.ksm"),
+        input_paths: Vec::new(),
+        output_path: PathBuf::from("./tests/global/globals.ksm"),
         entry_point: String::from("_start"),
         shared: false,
         debug: true,
     };
 
-    let mut driver = Driver::new(config.to_owned());
+    let mut driver = Driver::new(config);
 
     driver.add_file(String::from("main.ko"), main_ko);
     driver.add_file(String::from("lib.ko"), lib_ko);
@@ -65,7 +66,7 @@ fn link_with_globals() {
         }
         Err(e) => {
             eprintln!("{}", e);
-            assert!(false, "Failed to link globals");
+            panic!("Failed to link globals");
         }
     }
 }

--- a/tests/local-test.rs
+++ b/tests/local-test.rs
@@ -1,4 +1,5 @@
 use std::io::{Read, Write};
+use std::path::PathBuf;
 
 use kerbalobjects::{
     kofile::{
@@ -53,14 +54,14 @@ fn link_with_locals() {
     let intlib_ko = KOFile::from_bytes(&mut buffer_iter, false).expect("Error reading KO file");
 
     let config = CLIConfig {
-        file_paths: Vec::new(),
-        output_path_value: String::from("./tests/locals.ksm"),
+        input_paths: Vec::new(),
+        output_path: PathBuf::from("./tests/locals.ksm"),
         entry_point: String::from("_start"),
         shared: false,
         debug: true,
     };
 
-    let mut driver = Driver::new(config.to_owned());
+    let mut driver = Driver::new(config);
 
     driver.add_file(String::from("main.ko"), main_ko);
     driver.add_file(String::from("floatlib.ko"), floatlib_ko);
@@ -80,7 +81,7 @@ fn link_with_locals() {
         }
         Err(e) => {
             eprintln!("{}", e);
-            assert!(false, "Failed to link locals");
+            panic!("Failed to link locals");
         }
     }
 }


### PR DESCRIPTION
This updates clap to 4.0, which is the newest version, and fixes a bunch of clippy warnings.